### PR TITLE
fix: update build-push script

### DIFF
--- a/build_push.sh
+++ b/build_push.sh
@@ -1,22 +1,22 @@
 #!/bin/bash
 set -e -x -u
 
-# bash script should be called with aws environment (dev / dev-green / prod)
-# other required configuration:
-# * APP
-# * DOCKER_REPO
-awsenv=$1
+# bash script should be called with the following environment variables set:
+# * DOCKER_SERVER: ECR repo domain
+
+DOCKER_REPO="$DOCKER_SERVER/cms-sync"
 
 # build docker image and tag it with git hash and aws environment
 githash=$(git rev-parse --short HEAD)
-docker build -t $APP:latest .
-docker tag $APP:latest $DOCKER_REPO:$awsenv
-docker tag $APP:latest $DOCKER_REPO:git-$githash
+docker build -t cms-sync:latest .
+docker tag cms-sync:latest $DOCKER_REPO:git-$githash
+docker tag cms-sync:latest $DOCKER_REPO:latest
 
-# retrieve the `docker login` command from AWS ECR and execute it
-logincmd=$(aws ecr get-login --no-include-email --region us-east-1)
-eval $logincmd
+# get ECR credentials
+aws ecr get-login-password --region us-east-1 \
+    | docker login --username AWS \
+        --password-stdin $DOCKER_SERVER
 
 # push images to ECS image repo
-docker push $DOCKER_REPO:$awsenv
+docker push $DOCKER_REPO:latest
 docker push $DOCKER_REPO:git-$githash


### PR DESCRIPTION
This script was borrowed from a shared deployment environment and was very outdated. Tweaked to run just `cms-sync`.

Long-term we should switch to using [the `build-push-ecr` action](https://github.com/mbta/actions/blob/main/build-push-ecr/action.yml) instead.