### PR TITLE
Revert "Also keep config in sync"

### DIFF
--- a/sync-pantheon.sh
+++ b/sync-pantheon.sh
@@ -18,24 +18,12 @@ terminus backup:create mbta.test
 echo -e "\nCloning live site to test..."
 terminus env:clone-content -v -y --cc mbta.live test
 
-# keep the test site configuration in sync with
-# the commit currently deployed to test
-terminus drush mbta.test -- cim -y
-terminus drush mbta.test -- updb -y
-terminus drush mbta.test -- cr
-
 # dev does not need an on-demand backup,
 # plus it has daily, scheduled backups
 
 # clone database and files to dev
 echo -e "\nCloning test site to dev..."
 terminus env:clone-content -v -y --cc mbta.test dev
-
-# keep the dev site configuration in sync with
-# the commit currently deployed to dev
-terminus drush mbta.dev -- cim -y
-terminus drush mbta.dev -- updb -y
-terminus drush mbta.dev -- cr
 
 # backup sandbox DB prior to sync
 echo -e "\nBacking up sandbox database..."


### PR DESCRIPTION
Reverts mbta/cms-sync#3

`drush` is currently incompatible, even when run via `terminus` subshell commands. 

`drush` expects a valid SSH key in the expected location to function properly.

Removing `drush` commands for the time being.